### PR TITLE
adding EX_RE_CA_* env variables for testing support

### DIFF
--- a/express/server.js
+++ b/express/server.js
@@ -11,7 +11,10 @@ app.set('port', process.env.PORT || 3027);
 
 /* ======== cache  ======== */
 var cache_options = {
-  expire      : 3
+  expire      : 3,
+  host        : process.env.EX_RE_CA_HOST || 'localhost',
+  port        : process.env.EX_RE_CA_PORT || 6379,
+  prefix      : process.env.EX_RE_CA_PREFIX || 'erct:'
 };
 
 var cache         = require('../')(cache_options);

--- a/test/ExpressRedisCache.js
+++ b/test/ExpressRedisCache.js
@@ -10,9 +10,9 @@
 
   var cache;
 
-  var prefix    =   'erct:';
-  var host      =   'localhost';
-  var port      =   6379;
+  var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+  var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+  var port      =   process.env.EX_RE_CA_PORT || 6379;
 
   describe ( 'Module', function () {
 

--- a/test/add.js
+++ b/test/add.js
@@ -10,9 +10,9 @@
 
   var config    =   require('../package.json').config;
 
-  var prefix    =   'erct:';
-  var host      =   'localhost';
-  var port      =   6379;
+  var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+  var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+  var port      =   process.env.EX_RE_CA_PORT || 6379;
 
   var _name     =   'test1';
   var _body     =   'test1 test1 test1';

--- a/test/del.js
+++ b/test/del.js
@@ -7,9 +7,9 @@
   var mocha     =   require('mocha');
   var should    =   require('should');
 
-  var prefix    =   'erct';
-  var host      =   'localhost';
-  var port      =   6379;
+  var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+  var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+  var port      =   process.env.EX_RE_CA_PORT || 6379;
 
   var cache     =   require('../')({
     prefix: prefix,

--- a/test/express.js
+++ b/test/express.js
@@ -6,9 +6,9 @@ var should    =   require('should');
 var request   =   require('request');
 var util      =   require('util');
 
-var prefix    =   'erct:';
-var host      =   'localhost';
-var port      =   6379;
+var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+var port      =   process.env.EX_RE_CA_PORT || 6379;
 
 var spawn,
     express_port,

--- a/test/get.js
+++ b/test/get.js
@@ -8,10 +8,10 @@
   var mocha     =   require('mocha');
   var should    =   require('should');
 
-  var prefix    =   'erct:';
-  var host      =   'localhost';
-  var port      =   6379;
-
+  var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+  var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+  var port      =   process.env.EX_RE_CA_PORT || 6379;
+  
   var _name     =   'test1';
   var _body     =   'test1 test1 test1';
   var _type     =   'text/plain';

--- a/test/route.js
+++ b/test/route.js
@@ -8,11 +8,10 @@
   var mocha     =   require('mocha');
   var should    =   require('should');
 
-
-  var prefix    =   'erct';
-  var host      =   'localhost';
-  var port      =   6379;
-
+  var prefix    =   process.env.EX_RE_CA_PREFIX || 'erct:';
+  var host      =   process.env.EX_RE_CA_HOST || 'localhost';
+  var port      =   process.env.EX_RE_CA_PORT || 6379;
+  
   var cache     =   require('../')({
     prefix: prefix,
     host: host,


### PR DESCRIPTION
The documentation mentions being able to use some EX_RE_CA_\* environment variables for running your tests. This pull request uses those variables (if defined).
