### PR TITLE
Fixing res.send to save only stringified objects to cache.

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -161,8 +161,12 @@ module.exports = (function () {
             res.send = function (body) {
 
               /** send output to HTTP client **/
+              var ret = send(body);
 
-              send(body);
+              /** save only strings to cache **/
+              if ( typeof body !== 'string' ) {
+                return ret;
+              }
 
               if ( this.expressRedisCache ) {
                 self.emit('deprecated', {
@@ -179,10 +183,13 @@ module.exports = (function () {
                 /** Create the new cache **/
                 self.add(name, body, {
                     type: this._headers['content-type'],
-                    expire: expirationPolicy(res.statusCode)
+                    expire: expire
                   },
                   domain.intercept(function (name, cache) {}));
               }
+
+              return ret;
+
             };
 
             next();

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -183,7 +183,7 @@ module.exports = (function () {
                 /** Create the new cache **/
                 self.add(name, body, {
                     type: this._headers['content-type'],
-                    expire: expire
+                    expire: expirationPolicy(res.statusCode)
                   },
                   domain.intercept(function (name, cache) {}));
               }


### PR DESCRIPTION
Changes: 
- Express's `response.send` returns the response stream itself. In our monkey-patch, we should do the same. 
- If the `body` passed to `response.send` is an object and not a buffer, `response.send` calls `response.json`, which later calls `response.send` to send the data to the client. This means that when we monkey-patch `response.send`, we end up saving to the cache twice. The first time, we save an object, the second, we save a string. Seeing as though all objects are converted to string eventually, it looks to me like we should only have the need to save strings in our redis cache. 
