### PR TITLE
Allow binary buffers

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -147,6 +147,11 @@ module.exports = (function () {
           expire = options[1];
         }
 
+        var binary = false;
+        if ( typeof options[0] === 'object' && typeof options[0].binary === 'boolean' ) {
+          binary = options[0].binary;
+        }
+
         var expirationPolicy = require('./expire')(expire);
 
         /** attempt to get cache **/
@@ -162,7 +167,11 @@ module.exports = (function () {
 
           if ( cache.length ) {
             res.contentType(cache[0].type || "text/html");
-            res.send(cache[0].body);
+            if(binary){ //Convert back to binary buffer
+              res.send(new Buffer(cache[0].body, 'base64'));
+            }else{
+              res.send(cache[0].body);
+            }
           }
 
           /** otherwise, cache request **/
@@ -175,6 +184,11 @@ module.exports = (function () {
 
               /** send output to HTTP client **/
               var ret = send(body);
+
+              /** convert binary to base64 string **/
+              if(binary && typeof body !== 'string'){
+                body = new Buffer(body).toString('base64');
+              }
 
               /** save only strings to cache **/
               if ( typeof body !== 'string' ) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     {
       "name": "ramanpreetnara",
       "url": "https://github.com/ramanpreetnara"
+    },
+    {
+      "name": "mdbox",
+      "url": "https://github.com/mdbox"
     }
   ],
   "license": "BSD",


### PR DESCRIPTION
This will allow sending binary buffers by converting to a base64 string before storing to cache.  I added an option flag 'binary' to enable this feature.  
#51

``` javascript
router.get('/image/:guid', cache.route({binary: true}), function(req, res){
 ...
    res.status(200).send(new Buffer(body, 'binary'));
}
```
