### PR TITLE
add exit method when this middleware is finished

### DIFF
--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -20,6 +20,7 @@ module.exports = (function () {
     domain.on('error', function (error) {
       self.emit('error', error);
       callback(error);
+      domain.exit();
     });
 
     domain.run(function () {
@@ -35,7 +36,8 @@ module.exports = (function () {
 
       self.client.keys(prefix + ':' + name, domain.intercept(function (keys) {
         if ( ! keys.length ) {
-          return callback(null, []);
+          callback(null, []);
+          return domain.exit();
         }
 
         require('async').parallel(keys.map(function (key) {
@@ -51,6 +53,7 @@ module.exports = (function () {
           };
         }), domain.intercept(function (results) {
           callback(null, results);
+          domain.exit();
         }));
       }));
 


### PR DESCRIPTION
This is because, this domain will catch all the errors even after the callback is called, for example, this is a sample handler

``` javascript
router.get('/foo',[
    function(req, res) {
       cache.get('foo', function bar(err, entries) {
          var result;
          if (err) {
              result = [];
              //do something to recover
              console.log('err', err);
          } else {
            result = entries;
          }
          res.json({result: result});
          //do some clean up
          if (db.connected()) {
            db.disconnect();
            throw new Error('unexpected error');//for example
          }
       }
    },
]);
```

This will cause an infinite loop, which is the newly thrown error will be caught by the domain, then the fomain will call function bar with the error callback, then the program will continue to execute and res.json will be called more than one time, and on the second and above times res.json will throw an error("can not set header after sent"), this error will again be caught by the domain and the bar handler will be called again and the loop goes on....
