### PR TITLE
store and retrieve response status code

### DIFF
--- a/lib/ExpressRedisCache/add.js
+++ b/lib/ExpressRedisCache/add.js
@@ -12,7 +12,7 @@ module.exports = (function () {
    *  @callback
    *  @arg {String} name - The cache entry name
    *  @arg {String} body - The cache entry body
-   *  @arg {Object} options - Optional { type: String, expire: Number }
+   *  @arg {Object} options - Optional { type: String, expire: Number, status: Number }
    *  @arg {Number} expire - The cache life time in seconds [OPTIONAL]
    *  @arg {Function} callback
    */
@@ -44,6 +44,7 @@ module.exports = (function () {
       var entry = {
         body: body,
         type: options.type || config.type,
+        status: options.status || 200,
         touched: +new Date(),
         expire: options.expire || self.expire
       };

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -167,6 +167,7 @@ module.exports = (function () {
 
           if ( cache.length ) {
             res.contentType(cache[0].type || "text/html");
+            res.status(cache[0].status);
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{
@@ -198,6 +199,7 @@ module.exports = (function () {
               /** Create the new cache **/
               self.add(name, body, {
                   type: this._headers['content-type'],
+                  status: this.statusCode,
                   expire: expirationPolicy(res.statusCode)
                 },
                 domain.intercept(function (name, cache) {}));


### PR DESCRIPTION
Correction that stores and serves from cache http response status codes. This is important when for example part of application crashes after expensive computing and returns "500" to web browser. When responding with 200 status code and error message, response can be for example cached client side.
