### PR TITLE
Avoid keys call

### DIFF
--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -57,7 +57,8 @@ module.exports = (function () {
         /** Get a list of keys using the wildcard */
         self.client.keys(prefix + ':' + name, domain.intercept(function (keys) {
           if ( ! keys.length ) {
-            return callback(null, []);
+            callback(null, []);
+            return domain.exit();
           }
 
           require('async').parallel(keys.map(function (key) {
@@ -66,6 +67,7 @@ module.exports = (function () {
             };
           }), domain.intercept(function (results) {
             callback(null, results);
+            domain.exit();
           }));
         }));
       }
@@ -74,9 +76,11 @@ module.exports = (function () {
         fetchKey(redisKey, domain.intercept(function (result) {
           if( result ) {
             callback(null, [ result ]);
+            domain.exit();
           }
           else {
             callback(null, []);
+            domain.exit();
           }
         }));
       }

--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -34,29 +34,52 @@ module.exports = (function () {
       var prefix = self.prefix.match(/:$/) ? self.prefix.replace(/:$/, '')
         : self.prefix;
 
-      self.client.keys(prefix + ':' + name, domain.intercept(function (keys) {
-        if ( ! keys.length ) {
-          callback(null, []);
-          return domain.exit();
-        }
+      var redisKey = prefix + ':' + (name ||'*');
 
-        require('async').parallel(keys.map(function (key) {
-          return function (cb) {
-            self.client.hgetall(key, domain.intercept(function (result) {
-              var names = key.split(':');
-              result.name = names[1];
-              result.prefix = names[0];
-              self.emit('message', require('util').format('GET %s ~%d Kb', key,
-                (require('../sizeof')(result) / 1024).toFixed(2)));
-              cb(null, result);
-            }));
-          };
-        }), domain.intercept(function (results) {
-          callback(null, results);
-          domain.exit();
+      /** Detect wildcard syntax */
+      var hasWildcard = redisKey.indexOf('*') >= 0;
+
+      var fetchKey = function (key, cb) {
+        self.client.hgetall(key, domain.intercept(function (result) {
+          if ( result ) {
+            var names = key.split(':');
+            result.name = names[1];
+            result.prefix = names[0];
+            self.emit('message', require('util').format('GET %s ~%d Kb', key,
+              (require('../sizeof')(result) / 1024).toFixed(2)));
+          }
+          cb(null, result);
         }));
-      }));
+      };
 
+      /** If has wildcard */
+      if ( hasWildcard ) {
+        /** Get a list of keys using the wildcard */
+        self.client.keys(prefix + ':' + name, domain.intercept(function (keys) {
+          if ( ! keys.length ) {
+            return callback(null, []);
+          }
+
+          require('async').parallel(keys.map(function (key) {
+            return function (cb) {
+              return fetchKey(key, cb);
+            };
+          }), domain.intercept(function (results) {
+            callback(null, results);
+          }));
+        }));
+      }
+      /** No wildcard **/
+      else {
+        fetchKey(redisKey, domain.intercept(function (result) {
+          if( result ) {
+            callback(null, [ result ]);
+          }
+          else {
+            callback(null, []);
+          }
+        }));
+      }
     });
   }
 

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -82,19 +82,6 @@ module.exports = (function () {
           return next();
         }
 
-        // If the cache gets disconnected, call next()
-        /* NOTE: The disconnected event is emitted after any redis client completes it's configured max_attempts and delay throttling.
-
-        This will throw a nasty error regarding headers when this occurs along the lines of:
-            Error: Can't set headers after they are sent. 
-              at ServerResponse.OutgoingMessage.setHeader...
-
-           ...but it will allow the request to be completed without blocking.  Subsequent requests pass through as self.connected is false.
-        */
-        self.on('disconnected', function () {
-          return next();
-        });
-
         /** Cache entry name
          *
          *  @type String

--- a/test/get.js
+++ b/test/get.js
@@ -73,6 +73,51 @@
       });
     });
 
+    it ( 'should support wildcard gets', function (done) {
+      cache.add('wildkey1', 'abc',
+        function ($error, $name, $entry) {
+          cache.add('wildkey2', 'def',
+            function ($error, $name, $entry) {
+              cache.get('wildkey*', function ($error, $results) {
+                $results.should.be.an.Array;
+                $results.should.have.a.lengthOf(2);
+                done();
+              });
+            });
+        });
+    });
+
+    it ( 'should support specific gets without calling keys', function (done) {
+
+      // wrap the call to keys, so we can see if it's called
+      var callCount = 0;
+      var wrap = function(fn){
+        return function(){
+          console.log('What!?');
+          callCount++;
+          return fn.apply(this, arguments);
+        };
+      };
+
+      cache.client.keys = wrap(cache.client.keys);
+
+      cache.add('wildkey1', 'abc',
+        function ($error, $name, $entry) {
+          cache.add('wildkey2', 'def',
+            function ($error, $name, $entry) {
+              cache.get('wildkey1', function ($error, $results) {
+                try {
+                  $results.should.be.an.Array;
+                  $results.should.have.a.lengthOf(1);
+                  callCount.should.equal(0);
+                  done();
+                } catch (e) {
+                  done(e);
+                }
+              });
+            });
+        });
+    });
   });
 
 })();


### PR DESCRIPTION
For most cases, where the key is not a wildcard key, we can directly try to fetch just that key.  Still support the cases where a wildcard is desired.  This avoids the expensive KEYS call for the majority of cases, which significantly reduces impact on performance.
This should fix #55 and fix #68 and fix #56 
