### PR TITLE
Extend usage to restify

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -166,7 +166,11 @@ module.exports = (function () {
           /** if it's cached, display cache **/
 
           if ( cache.length ) {
-            res.contentType(cache[0].type || "text/html");
+            if (res.contentType) {
+				      res.contentType(cache[0].type || "text/html");
+			      } else if (res.setHeader) {
+				      res.setHeader('content-type', cache[0].type || "text/html");
+			      }
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -167,10 +167,10 @@ module.exports = (function () {
 
           if ( cache.length ) {
             if (res.contentType) {
-				      res.contentType(cache[0].type || "text/html");
-			      } else if (res.setHeader) {
-				      res.setHeader('content-type', cache[0].type || "text/html");
-			      }
+              res.contentType(cache[0].type || "text/html");
+            } else if (res.setHeader) {
+              res.setHeader('content-type', cache[0].type || "text/html");
+            }
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{


### PR DESCRIPTION
when using restify; res.contentType generates:

```
{ [TypeError: res.contentType is not a function]
  domain: 
   Domain {
     domain: null,
     _events: { error: [Function] },
     _eventsCount: 1,
     _maxListeners: undefined,
     members: [] },
  domainThrown: true }
```
