### PR TITLE
Allow calling cache.route with options that include a function to determine the expiration of the cache entry.

### DIFF
--- a/lib/ExpressRedisCache/expire.js
+++ b/lib/ExpressRedisCache/expire.js
@@ -47,7 +47,7 @@ module.exports = (function () {
       throw new Error('no default expiration provided');
     }
 
-    return function (res) {
+    return function (req, res) {
       var statusCode = res.statusCode;
 
       // Look for exact status code matches first

--- a/lib/ExpressRedisCache/expire.js
+++ b/lib/ExpressRedisCache/expire.js
@@ -10,8 +10,13 @@ module.exports = (function () {
   // Turn the policy argument into a function that consumes a
   // status code and returns the expiration value
   function createExpirationPolicy (options) {
-    if (typeof options !== 'object' && typeof options !== 'number') {
+    if (typeof options !== 'object' && typeof options !== 'number' && typeof options !== 'function') {
       throw new Error('expire option cannot be type ' + typeof options);
+    }
+
+    // If what's passed in is a function, return the function.
+    if ( typeof options === 'function' ) {
+      return options;
     }
 
     // Internally store expiration as an object,
@@ -42,7 +47,9 @@ module.exports = (function () {
       throw new Error('no default expiration provided');
     }
 
-    return function (statusCode) {
+    return function (res) {
+      var statusCode = res.statusCode;
+
       // Look for exact status code matches first
       if (options.hasOwnProperty(statusCode)) {
         return options[statusCode];

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -198,7 +198,7 @@ module.exports = (function () {
               /** Create the new cache **/
               self.add(name, body, {
                   type: this._headers['content-type'],
-                  expire: expirationPolicy(res)
+                  expire: expirationPolicy(req, res)
                 },
                 domain.intercept(function (name, cache) {}));
 

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -66,9 +66,9 @@ module.exports = (function () {
             file: __fileName,
             line: __line
           });
-            
+
           res.use_express_redis_cache = res.expressRedisCache;
-            
+
         }
 
         // If cache is disabled, call next()
@@ -77,7 +77,7 @@ module.exports = (function () {
         }
 
         // If the cache isn't connected, call next()
-          
+
         if ( self.connected === false || self.client.connected === false ) {
           return next();
         }
@@ -135,7 +135,7 @@ module.exports = (function () {
          */
         var expire = self.expire;
         if ( typeof options[0] === 'object' ) {
-          if ( typeof options[0].expire === 'number' || typeof options[0].expire === 'object' ) {
+          if ( typeof options[0].expire === 'number' || typeof options[0].expire === 'object' || typeof options[0].expire === 'function') {
             expire = options[0].expire;
           }
         }
@@ -198,7 +198,7 @@ module.exports = (function () {
               /** Create the new cache **/
               self.add(name, body, {
                   type: this._headers['content-type'],
-                  expire: expirationPolicy(res.statusCode)
+                  expire: expirationPolicy(res)
                 },
                 domain.intercept(function (name, cache) {}));
 

--- a/test/expire.js
+++ b/test/expire.js
@@ -81,11 +81,11 @@
     })
 
     it ( 'should return the specified value for all status codes', function () {
-      createExpirationPolicy(-1)(200).should.equal(-1);
-      createExpirationPolicy(1)(300).should.equal(1);
-      createExpirationPolicy(22)(403).should.equal(22)
-      createExpirationPolicy(333)(404).should.equal(333)
-      createExpirationPolicy(4444)(500).should.equal(4444)
+      createExpirationPolicy(-1)({ statusCode: 200 }).should.equal(-1);
+      createExpirationPolicy(1)({ statusCode: 300 }).should.equal(1);
+      createExpirationPolicy(22)({ statusCode: 403 }).should.equal(22)
+      createExpirationPolicy(333)({ statusCode: 404 }).should.equal(333)
+      createExpirationPolicy(4444)({ statusCode: 500 }).should.equal(4444)
     });
 
     it ( 'should return the appropriate value for status codes', function () {
@@ -102,17 +102,17 @@
         '5xx': 5,
         '500': 500
       });
-      policy(500).should.equal(500);
-      policy(501).should.equal(5);
-      policy(404).should.equal(404);
-      policy(403).should.equal(403);
-      policy(400).should.equal(400);
-      policy(480).should.equal(4);
-      policy(200).should.equal(200);
-      policy(201).should.equal(2);
-      policy(100).should.equal(100);
-      policy(101).should.equal(1);
-      policy(300).should.equal(-1);
+      policy({ statusCode: 500 }).should.equal(500);
+      policy({ statusCode: 501 }).should.equal(5);
+      policy({ statusCode: 404 }).should.equal(404);
+      policy({ statusCode: 403 }).should.equal(403);
+      policy({ statusCode: 400 }).should.equal(400);
+      policy({ statusCode: 480 }).should.equal(4);
+      policy({ statusCode: 200 }).should.equal(200);
+      policy({ statusCode: 201 }).should.equal(2);
+      policy({ statusCode: 100 }).should.equal(100);
+      policy({ statusCode: 101 }).should.equal(1);
+      policy({ statusCode: 300 }).should.equal(-1);
     });
 
     it ( 'should treat status code keys as case insensitive', function () {
@@ -120,8 +120,8 @@
         '1XX': 1,
         'xXx': 55
       });
-      policy(101).should.equal(1);
-      policy(200).should.equal(55);
+      policy({ statusCode: 101 }).should.equal(1);
+      policy({ statusCode: 200 }).should.equal(55);
     });
   });
 })();

--- a/test/expire.js
+++ b/test/expire.js
@@ -81,11 +81,11 @@
     })
 
     it ( 'should return the specified value for all status codes', function () {
-      createExpirationPolicy(-1)({ statusCode: 200 }).should.equal(-1);
-      createExpirationPolicy(1)({ statusCode: 300 }).should.equal(1);
-      createExpirationPolicy(22)({ statusCode: 403 }).should.equal(22)
-      createExpirationPolicy(333)({ statusCode: 404 }).should.equal(333)
-      createExpirationPolicy(4444)({ statusCode: 500 }).should.equal(4444)
+      createExpirationPolicy(-1)(null, { statusCode: 200 }).should.equal(-1);
+      createExpirationPolicy(1)(null, { statusCode: 300 }).should.equal(1);
+      createExpirationPolicy(22)(null, { statusCode: 403 }).should.equal(22);
+      createExpirationPolicy(333)(null, { statusCode: 404 }).should.equal(333);
+      createExpirationPolicy(4444)(null, { statusCode: 500 }).should.equal(4444);
     });
 
     it ( 'should return the appropriate value for status codes', function () {
@@ -102,17 +102,17 @@
         '5xx': 5,
         '500': 500
       });
-      policy({ statusCode: 500 }).should.equal(500);
-      policy({ statusCode: 501 }).should.equal(5);
-      policy({ statusCode: 404 }).should.equal(404);
-      policy({ statusCode: 403 }).should.equal(403);
-      policy({ statusCode: 400 }).should.equal(400);
-      policy({ statusCode: 480 }).should.equal(4);
-      policy({ statusCode: 200 }).should.equal(200);
-      policy({ statusCode: 201 }).should.equal(2);
-      policy({ statusCode: 100 }).should.equal(100);
-      policy({ statusCode: 101 }).should.equal(1);
-      policy({ statusCode: 300 }).should.equal(-1);
+      policy(null, { statusCode: 500 }).should.equal(500);
+      policy(null, { statusCode: 501 }).should.equal(5);
+      policy(null, { statusCode: 404 }).should.equal(404);
+      policy(null, { statusCode: 403 }).should.equal(403);
+      policy(null, { statusCode: 400 }).should.equal(400);
+      policy(null, { statusCode: 480 }).should.equal(4);
+      policy(null, { statusCode: 200 }).should.equal(200);
+      policy(null, { statusCode: 201 }).should.equal(2);
+      policy(null, { statusCode: 100 }).should.equal(100);
+      policy(null, { statusCode: 101 }).should.equal(1);
+      policy(null, { statusCode: 300 }).should.equal(-1);
     });
 
     it ( 'should treat status code keys as case insensitive', function () {
@@ -120,8 +120,8 @@
         '1XX': 1,
         'xXx': 55
       });
-      policy({ statusCode: 101 }).should.equal(1);
-      policy({ statusCode: 200 }).should.equal(55);
+      policy(null, { statusCode: 101 }).should.equal(1);
+      policy(null, { statusCode: 200 }).should.equal(55);
     });
   });
 })();


### PR DESCRIPTION
We needed a way to set the expiration of each cache entry to a custom time (the response includes a calculated expiration date, at which point we wanted the entry to expire from the cache). This should allow clients to optionally pass in a custom expire function for each call to cache.route().

Example:

```
app.get("/v1/myroute/:id", cache.route({ expire: calculateExpiration }), function(req, res) {
    // My route processing
    ...
});

var calculateExpiration = function(res) {
    // Do some magic
    ...

    return expire;
}
```
