### PR TITLE
Handle case where key has expired or been deleted

### DIFF
--- a/lib/ExpressRedisCache/add.js
+++ b/lib/ExpressRedisCache/add.js
@@ -44,6 +44,7 @@ module.exports = (function () {
       var entry = {
         body: body,
         type: options.type || config.type,
+        statusCode: options.statusCode,
         touched: +new Date(),
         expire: (typeof options.expire !== 'undefined' && options.expire !== false) ? options.expire : self.expire
       };

--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -42,7 +42,7 @@ module.exports = (function () {
           return function (cb) {
             self.client.hgetall(key, domain.intercept(function (result) {
               if ( ! result ) {
-                cb(null, null)
+                return cb(null, null)
               }
 
               var names = key.split(':');

--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -41,6 +41,10 @@ module.exports = (function () {
         require('async').parallel(keys.map(function (key) {
           return function (cb) {
             self.client.hgetall(key, domain.intercept(function (result) {
+              if ( ! result ) {
+                cb(null, null)
+              }
+
               var names = key.split(':');
               result.name = names[1];
               result.prefix = names[0];

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -165,7 +165,7 @@ module.exports = (function () {
 
           /** if it's cached, display cache **/
 
-          if ( cache.length ) {
+          if ( cache.length && cache[0] ) {
             res.contentType(cache[0].type || "text/html");
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -170,7 +170,7 @@ module.exports = (function () {
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{
-              res.send(cache[0].body);
+              res.status(cache[0].statusCode || 200).send(cache[0].body);
             }
           }
 
@@ -198,7 +198,8 @@ module.exports = (function () {
               /** Create the new cache **/
               self.add(name, body, {
                   type: this._headers['content-type'],
-                  expire: expirationPolicy(res.statusCode)
+                  expire: expirationPolicy(res.statusCode),
+                  statusCode: this.statusCode
                 },
                 domain.intercept(function (name, cache) {}));
 


### PR DESCRIPTION
This PR fixes a bug caused by express-redis-cache attempting to get a key that has been deleted or expired. 

This scenarios happens like this:
1. key is looked up in Redis [get.js, line 36](https://github.com/rv-kip/express-redis-cache/blob/master/lib/ExpressRedisCache/get.js#L36)
2. key expires or is deleted from Redis
3. key is retrieved from Redis [get.js, line 43](https://github.com/rv-kip/express-redis-cache/blob/master/lib/ExpressRedisCache/get.js#L43). `hgetall` returns null since the key no longer exists.
4. the function attempts to set properties on the null value, [get.js, line 45](https://github.com/rv-kip/express-redis-cache/blob/master/lib/ExpressRedisCache/get.js#L45) which results in an error being thrown and the app crashing.

I ran the tests and they all pass though I did not add a new test. Due to the nature of this bug I wasn't sure how to go about creating a new test. Please let me know if I need to make some changes. Thanks.
