### PR TITLE
Feature: express_redis_cache_expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ app.get('/index.html',
   function (req, res)  { ... });
 ```
 
+Also, you can use `res.express_redis_cache_expire` to change expiration:
+
+```js
+app.post('/expensive-query-service',
+  function (req, res, next) {
+    // set expiration
+    res.express_redis_cache_expire = 20; // (for example: req.body.expire - user defined expiration from request)
+    next();
+  },
+
+  // cache middleware
+  cache.route(), // cache.route(15) will override express_redis_cache_expire to this value (15)
+
+  // content middleware
+  function (req, res) {
+    res.render('query result');
+  }
+);
+```
+
 You can also specify
 
 # Content Type

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -147,6 +147,11 @@ module.exports = (function () {
          *  @default this.expire
          */
         var expire = self.expire;
+        
+        if ( typeof res.express_redis_cache_expire === 'number' && ! isNaN(res.express_redis_cache_expire) ) {
+          expire = res.express_redis_cache_expire;
+        }
+
         if ( typeof options[0] === 'object' ) {
           if ( typeof options[0].expire === 'number' || typeof options[0].expire === 'object' || typeof options[0].expire === 'function') {
             expire = options[0].expire;


### PR DESCRIPTION
This PR adds possibility to set expire time via `res.express_redis_cache_expire` option.

I have queries on which I need to set `expire` from client side, so it can look like this:
```js
app.post(
	'/expensive-query',
	(req, res, next) => {
		res.express_redis_cache_name = 'expensive-query-' + req.body.limit + '-' + req.body.cacheTime
		res.express_redis_cache_expire = parseInt(req.body.cacheTime)
		next()
	},
	cache.route(),
	(req, res, next) => {
		res.send('result')
	}
)
```