### PR TITLE
Do not cache responses set to expire at 0

### DIFF
--- a/lib/ExpressRedisCache/add.js
+++ b/lib/ExpressRedisCache/add.js
@@ -79,7 +79,7 @@ module.exports = (function () {
       {
         // Do not cache entries that are set to expire at 0
         // You can use -1 to not let an entry expire
-        callback()
+        callback(null, name, entry)
       }
     });
   }

--- a/lib/ExpressRedisCache/add.js
+++ b/lib/ExpressRedisCache/add.js
@@ -55,23 +55,32 @@ module.exports = (function () {
 
       /* Save as a Redis hash */
       var redisKey = prefix + ':' + name;
-      self.client.hmset(redisKey, entry,
-        domain.intercept(function (res) {
-          var calculated_size = (size / 1024).toFixed(2);
-          /** If @expire then tell Redis to expire **/
-          if ( typeof entry.expire === 'number' && entry.expire > 0 ) {
-            self.client.expire(redisKey, +entry.expire,
-              domain.intercept(function () {
-                self.emit('message', require('util').format('SET %s ~%d Kb %d TTL (sec)', redisKey, calculated_size, +entry.expire));
-                callback(null, name, entry, res);
-              }));
-          }
-          else
-          {
-            self.emit('message', require('util').format('SET %s ~%d Kb', redisKey, calculated_size));
-            callback(null, name, entry, res);
-          }
-        }));
+      if (entry.expire !== 0) {
+        self.client.hmset(redisKey, entry,
+          domain.intercept(function (res) {
+            var calculated_size = (size / 1024).toFixed(2);
+            /** If @expire then tell Redis to expire **/
+            if ( typeof entry.expire === 'number' && entry.expire > 0 ) {
+              self.client.expire(redisKey, +entry.expire,
+                domain.intercept(function () {
+                  self.emit('message', require('util').format('SET %s ~%d Kb %d TTL (sec)', redisKey, calculated_size, +entry.expire));
+                  callback(null, name, entry, res);
+                }));
+            }
+            else
+            {
+              self.emit('message', require('util').format('SET %s ~%d Kb', redisKey, calculated_size));
+              callback(null, name, entry, res);
+            }
+          })
+        );
+      }
+      else
+      {
+        // Do not cache entries that are set to expire at 0
+        // You can use -1 to not let an entry expire
+        callback()
+      }
     });
   }
 


### PR DESCRIPTION
Currently any expire set to 0 or below would make an entry to never expire.
We believe caching errors like 4xx or 5xx is wrong, but like the ability to customize it that you propose.
So we made a little change to not allow caching when the expire is set to 0, leaving the ability to have expire set to -1  for infinity, or any other number greater than 0.
We tried to respect your sintax as well.