### PR TITLE
Fix this.connected bug when connect event is missed

### DIFF
--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -96,6 +96,10 @@ module.exports = (function () {
         this.emit('disconnected', { host: this.host, port: this.port });
         this.emit('message', 'Disconnected from redis://' + this.client.host + ':' + this.client.port);
       }.bind(this));
+      
+      if ( this.client.connected ) {
+        this.client.emit('connect');
+      }
     }
   }
 

--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -85,11 +85,12 @@ module.exports = (function () {
         this.emit('error', error);
       }.bind(this));
 
-      this.client.on('connect', function () {
+      function onConnect() {
         this.connected = true;
         this.emit('connected', { host: this.host, port: this.port });
         this.emit('message', 'OK connected to redis://' + this.client.address);
-      }.bind(this));
+      }
+      this.client.on('connect', onConnect.bind(this));
 
       this.client.on('end', function () {
         this.connected = false;
@@ -97,8 +98,8 @@ module.exports = (function () {
         this.emit('message', 'Disconnected from redis://' + this.client.host + ':' + this.client.port);
       }.bind(this));
       
-      if ( this.client.connected ) {
-        this.client.emit('connect');
+      if ( !this.connected && this.client.connected ) {
+        onConnect.bind(this)();
       }
     }
   }


### PR DESCRIPTION
This fix a bug that this.connected is not initialized if the redis connect event is missed.

Check if the connect event is missed or not, then emit the missed connect event again.