### PR TITLE
Use scan instead of keys for gets

### DIFF
--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -55,13 +55,13 @@ module.exports = (function () {
       /** If has wildcard */
       if ( hasWildcard ) {
         /** Get a list of keys using the wildcard */
-        self.client.keys(prefix + ':' + name, domain.intercept(function (keys) {
-          if ( ! keys.length ) {
+        self.client.scan(0, 'match', prefix + ':' + name, domain.intercept(function (result) {
+          if ( typeof result[1] === 'undefined' ) {
             callback(null, []);
             return domain.exit();
           }
 
-          require('async').parallel(keys.map(function (key) {
+          require('async').parallel(result[1].map(function (key) {
             return function (cb) {
               return fetchKey(key, cb);
             };


### PR DESCRIPTION
The `KEYS` command is really expensive in production. With ~500 ops/sec latency for reads and writes was between 5-7 seconds. Using the `SCAN` command instead reduced latency to manageable sub-second levels.