### PR TITLE
Fix for response hang if status was not present in cached response

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -167,7 +167,7 @@ module.exports = (function () {
 
           if ( cache.length &&  cache[0].body != null ) {
             res.contentType(cache[0].type || "text/html");
-            res.status(cache[0].status);
+            res.status(cache[0].status || 200);
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -165,9 +165,9 @@ module.exports = (function () {
 
           /** if it's cached, display cache **/
 
-          if ( cache.length &&  cache[0].body != null ) {
+          if ( cache.length &&  cache[0].body != null && cache[0].status) {
             res.contentType(cache[0].type || "text/html");
-            res.status(cache[0].status || 200);
+            res.status(cache[0].status);
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{


### PR DESCRIPTION
If the cached response was created by an older lib version which would not store Status Code, express-redis-case would set
```js
res.status(undefined)
```
which for me caused requests to hang forever.

Having the default status makes it transparently transition to storing response status.