### PR TITLE
[DEP0066] Replaced deprecated _headers property with getHeaders()

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -198,7 +198,7 @@ module.exports = (function () {
 
               /** Create the new cache **/
               self.add(name, body, {
-                  type: this._headers['content-type'],
+                  type: this.getHeaders()['content-type'],
                   status: this.statusCode,
                   expire: expirationPolicy(req, res)
                 },


### PR DESCRIPTION
expressjs apps using `express-redis-cache` log this error on the console:
```
(node:57103) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(Use `node --trace-deprecation ...` to show where the warning was created)
```
Replacing the deprecated `_headers` property with `getHeaders()` fixes this.

ref: DEP0066 - https://nodejs.org/api/deprecations.html#DEP0066