### PR TITLE
[2.0] Add cache status header option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This major version has been reworked to avoid breaking changes but some edge-cas
 
 ## New Features
 
-????
+### Cache status header
+
+You can now opt-in to get a cache status header in the response
+Use `res.express_redis_cache_status=true|false` - default to false
+The response will include the header `redis-cache-status=Hit|Miss`
 
 # Changes between 0.0.8 and 0.1.x
 
@@ -28,6 +32,7 @@ We introduced the `(Boolean) res.express_redis_cache_skip` property which, if se
 ### Deprecated event
 
 The code now emits a *deprecated* event when stumbling upon a deprecated part of the code. View below for more info.
+
 
 ## Fixes
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,13 @@ cache.on('deprecated', function (deprecated) {
 });
 ```
 
+## Cache status header
+
+You can opt-in to get a header in the response that gives you the status of the redis cache.
+Use `res.express_redis_cache_status=true|false` - default to false
+
+The response will include the header `redis-cache-status=Hit|Miss`
+
 # The Entry Model
 
 This is the object synopsis we use to represent a cache entry:

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -169,6 +169,9 @@ function route() {
       /** if it's cached, display cache **/
 
       if (cache.length && cache[0].body != null) {
+        if (res.express_redis_cache_status) {
+          res._headers["redis-cache-status"] = "Hit";
+        }
         res.contentType(cache[0].type || "text/html");
         if (binary) {
           //Convert back to binary buffer
@@ -177,6 +180,9 @@ function route() {
           res.send(cache[0].body);
         }
       } else {
+        if (res.express_redis_cache_status) {
+          res._headers["redis-cache-status"] = "Miss";
+        }
         /** otherwise, cache request **/
         /** wrap res.send **/
         let send = res.send.bind(res);

--- a/test/route.js
+++ b/test/route.js
@@ -55,6 +55,7 @@ describe("route", () => {
           throw error;
         }
         res._headers["cache-control"].should.equal("max-age=60000");
+        res._headers["redis-cache-status"].should.equal(undefined);
         res.send("hello folks!");
         done();
       });


### PR DESCRIPTION
### Cache status header

You can now opt-in to get a cache status header in the response
Use `res.express_redis_cache_status=true|false` - default to false
The response will include the header `redis-cache-status=Hit|Miss`