### PR TITLE
Move redis into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.1",
-    "colors": "^1.3.0",
-    "redis": "^2.4.2"
+    "colors": "^1.3.0"
   },
   "directories": {
     "test": "test"
@@ -74,6 +73,7 @@
     "method-override": "^2.3.10",
     "mocha": "^5.2.0",
     "moment": "^2.22.2",
+    "redis": "^2.4.2",
     "request": "^2.87.0",
     "should": "^13.2.1"
   }


### PR DESCRIPTION
Fixes #130.  `npm test` passes locally after this change.  Decided against using optionalDependencies as it sounds like `npm install` still installs optionalDependencies.  Not sure if peerDependency makes sense as it will show a warning when `redis` is not installed.

What do you think?