### PR TITLE
Fix for [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -198,7 +198,7 @@ module.exports = (function () {
 
               /** Create the new cache **/
               self.add(name, body, {
-                  type: this._headers['content-type'],
+                  type: this.getHeader('content-type'),
                   status: this.statusCode,
                   expire: expirationPolicy(req, res)
                 },


### PR DESCRIPTION
Changes `._headers` to `.getHeader` with it's proper header name